### PR TITLE
Fix/cicd cleanrepo

### DIFF
--- a/.github/workflows/repository_validation.yml
+++ b/.github/workflows/repository_validation.yml
@@ -38,7 +38,6 @@ jobs:
             -o -name "*#" \
             -o -name "#*" \
             -o -name "*.gcov" \
-            -o -name "core" \
             -o -name "vgcore.*" \
             -o -name "*.orig" \
             -o -name "*.rej" \


### PR DESCRIPTION
This pull request makes a minor update to the `.github/workflows/repository_validation.yml` workflow by removing the pattern that matches files named `core` from the list of file patterns to search for.

- Removed the `-o -name "core"` pattern from the file search command in `.github/workflows/repository_validation.yml`, so files named `core` will no longer be flagged by this workflow.