### PR TITLE
fix: added permission instanciation for cond mirroring

### DIFF
--- a/.github/workflows/conditional_mirroring.yml
+++ b/.github/workflows/conditional_mirroring.yml
@@ -14,8 +14,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 permissions:
-  contents: read
-
+  contents: write
+  actions: read
+  pages: write
+  id-token: write
 jobs:
 
   unit_tests:


### PR DESCRIPTION
This pull request updates the permissions section of the `.github/workflows/conditional_mirroring.yml` file to grant additional access required for the workflow to function correctly.

Most important change:

- Updated workflow permissions to allow write access to `contents`, `pages`, and `id-token`, and read access to `actions` to support necessary GitHub Actions operations.