### PR TITLE
fix: now unit tests session installs libsfml

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -57,7 +57,8 @@ jobs:
             gcc g++ \
             doxygen python3 python3-pip \
             clang clang-tidy cppcheck \
-            unzip curl
+            unzip curl \
+            libsfml-dev libsfml-audio2.6 libsfml-graphics2.6 libsfml-window2.6 libsfml-system2.6
       
       - name: Install CodeChecker for advanced analysis
         run: |


### PR DESCRIPTION
This pull request makes a small update to the unit test workflow by adding SFML development libraries and components to the build environment. This ensures that projects depending on SFML will have the necessary dependencies available during CI runs.

- Added installation of `libsfml-dev` and related SFML 2.6 component packages (`libsfml-audio2.6`, `libsfml-graphics2.6`, `libsfml-window2.6`, `libsfml-system2.6`) to the `unit_tests.yml` workflow to support SFML-based builds.