### PR TITLE
Docs/orga/GitHub official doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,500 @@
+# Contributing to R-Type
+
+Thank you for your interest in contributing to the R-Type project! This document provides all the guidelines and standards you need to follow when contributing to this project.
+
+## 📋 Table of Contents
+
+- [Code of Conduct](#code-of-conduct)
+- [Getting Started](#getting-started)
+- [Development Workflow](#development-workflow)
+- [Git Standards](#git-standards)
+- [Coding Standards](#coding-standards)
+- [Testing](#testing)
+- [Documentation](#documentation)
+- [Communication](#communication)
+- [Review Process](#review-process)
+
+---
+
+## 📜 Code of Conduct
+
+This project adheres to the [Contributor Covenant Code of Conduct](./docs/CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to [morgan.guichard@epitech.eu](mailto:morgan.guichard@epitech.eu).
+
+**Key Principles:**
+- Be respectful and inclusive
+- Accept constructive feedback gracefully
+- Focus on what is best for the community
+- Show empathy towards other community members
+
+---
+
+## 🚀 Getting Started
+
+### Prerequisites
+
+- **C++ Compiler**: GCC 13.3.0 or later
+- **CMake**: Version 3.20 or later
+- **Ninja**: Build system
+- **SFML**: Version 2.5.1 or later
+- **Criterion**: Testing library (optional, for full test suite)
+
+### Building the Project
+
+```bash
+# Clone the repository
+git clone https://github.com/morgangch/rtype.git
+cd rtype
+
+# Build the project
+cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
+cmake --build build --parallel $(nproc)
+
+# Run tests
+cd build
+ctest --output-on-failure
+```
+
+### Project Structure
+
+```
+rtype/
+├── client/          # Client application
+├── server/          # Server application
+├── common/          # Shared components and utilities
+├── lib/             # Internal libraries (ECS, MapParser, etc.)
+├── tests/           # Unit tests
+├── examples/        # Example programs and demos
+├── assets/          # Game assets (maps, fonts, etc.)
+└── docs/            # Documentation
+```
+
+---
+
+## 🔄 Development Workflow
+
+### Team Organization
+
+#### Daily Stand-ups (Tuesday & Wednesday)
+- **Time**: 10:00 AM (latest)
+- **Duration**: 15 minutes max
+- **Format**: Answer 3 questions:
+  1. What did I do yesterday?
+  2. What will I do today?
+  3. Any blockers or issues?
+- **Mandatory**: Retranscription on Notion after each daily
+- **Attendance**: Strongly recommended (not mandatory)
+- **If absent**: Must catch up on Notion retranscription
+
+#### Weekly Meetings (Monday)
+- **Time**: 2:00 PM (latest)
+- **Duration**: 30-60 minutes
+- **Objectives**:
+  - Define sprint goals and tasks
+  - Assign roles and tickets
+  - Perform `dev → main` merge if conditions are met
+- **Attendance**: Mandatory for all active members
+- **Mandatory**: Retranscription on Notion after each weekly
+
+### Task Management
+
+- All tasks are managed via **GitHub Projects**
+- Each ticket must include:
+  - ✅ Clear description of requirements
+  - 👤 One or more assignees
+  - 📅 Realistic deadline
+  - 🎯 Milestone (sprint) if applicable
+- Link tickets to PRs via the "Development" tab
+- Move tickets through workflow:
+  - **To Do** → **In Progress** → **In Review** → **Done**
+
+---
+
+## 🌿 Git Standards
+
+Our Git workflow follows [Conventional Commits](https://www.conventionalcommits.org/).
+
+### Commit Message Format
+
+```
+{action}: {brief description} {related issue(s)}
+```
+
+**Actions:**
+- `feat`: New feature
+- `fix`: Bug fix
+- `refacto`: Code refactoring
+- `docs`: Documentation changes
+
+**Examples:**
+```bash
+feat: add user authentication system #42
+fix: resolve memory leak in ECS component #87
+refacto: optimize map parser performance #65
+docs: update API documentation for MapParser #91
+```
+
+### Branch Naming Convention
+
+```
+{type}/{scope}/{topic}
+```
+
+**Structure:**
+- **type**: `feat`, `fix`, `refacto`, `docs`
+- **scope**: Component/domain (e.g., `server`, `client`, `ecs`, `mapparser`, `cicd`)
+- **topic**: Max 3 keywords describing the branch
+
+**Examples:**
+```bash
+feat/server/authentication-system
+fix/client/rendering-crash
+refacto/ecs/component-manager
+docs/mapparser/api-reference
+```
+
+### Pull Request Process
+
+1. **Create Pull Request**
+   - Always create a PR for merging (no direct commits to `dev` or `main`)
+   - Use descriptive title following commit conventions
+   - Add `closes #issue_number` at the bottom of the description
+
+2. **Generate Copilot Summary**
+   - Always generate a GitHub Copilot summary in the PR description
+   - Include technical details and changes made
+
+3. **Add to GitHub Project**
+   - Link PR via "Development" tab
+   - Move associated ticket to **"In Review"** column
+
+4. **Reviews Required**
+   - Minimum: GitHub Copilot review + 1-2 human reviewers
+   - Exception: Merges to `main` require team consensus (daily meeting)
+
+5. **Merge Strategy**
+   - Always use **Squash and Merge**
+   - Only after all reviews are approved
+   - Address all AI and human feedback
+
+6. **Merge to Main**
+   - From `dev` to `main` only
+   - Performed during weekly meetings
+   - Requires collective validation
+
+---
+
+## 💻 Coding Standards
+
+Full details in [CODING_STYLE.md](./docs/CODING_STYLE.md).
+
+### Documentation
+
+All code must be documented using **Doxygen**:
+
+```cpp
+/**
+ * @brief Brief description of the function or class.
+ * @param param_name Description of the parameter.
+ * @return Description of return value.
+ * @throws Exception(s) if applicable.
+ */
+```
+
+**Requirements:**
+- Documentation in **English** only
+- Each `.h` file starts with `@file` block
+- Document all public classes, methods, and functions
+
+### Naming Conventions
+
+| Element    | Convention | Example                  |
+|------------|------------|--------------------------|
+| Classes    | PascalCase | `PlayerManager`          |
+| Methods    | camelCase  | `getPlayerName()`        |
+| Variables  | snake_case | `player_count`           |
+| Constants  | UPPERCASE  | `MAX_PLAYERS`            |
+| Namespaces | lowercase  | `namespace network {...}`|
+
+### Code Quality Rules
+
+- ✅ Use `.cpp` for source files, `.h` for headers
+- ✅ Use `#ifndef` guards (NEVER `#pragma once`)
+- ❌ NO `using namespace std;`
+- ✅ Always initialize variables
+- ✅ Follow MISRA C++ and CERT C++ guidelines
+- ✅ Pass `cppcheck` and `clang-tidy` validation
+
+### File Structure
+
+```cpp
+/*
+** EPITECH PROJECT, 2025
+** rtype
+** File description:
+** Brief description of the file
+*/
+
+/**
+ * @file filename.h
+ * @brief Purpose of this file.
+ */
+
+#ifndef FILENAME_H
+#define FILENAME_H
+
+// Includes
+// Class/function declarations
+
+#endif // FILENAME_H
+```
+
+### Libraries and Modularity
+
+- Each reusable feature → separate library in `/lib/`
+- Each library must:
+  - Have its own `CMakeLists.txt`
+  - Include headers in `/include/libname/`
+  - Use a dedicated namespace
+- Minimize dependencies between modules
+
+---
+
+## 🧪 Testing
+
+### Test Requirements
+
+- All tests in `/tests/` directory
+- Each PR must include tests for new features
+- All tests must pass before merge
+- Test coverage should be maintained or improved
+
+### Running Tests
+
+```bash
+# Build and run all tests
+cd build
+ctest --output-on-failure
+
+# Run specific test
+./tests/test_mapparser
+
+# Run with verbose output
+ctest -R MapParserTest --verbose
+```
+
+### Writing Tests
+
+Follow the project's test style (assert-based):
+
+```cpp
+int test_feature() {
+    std::cout << "[TEST] Feature description..." << std::endl;
+    
+    // Setup
+    YourClass instance;
+    
+    // Test
+    int result = instance.someMethod();
+    
+    // Assertions
+    assert(result == expected_value);
+    
+    std::cout << "  PASS: Test description" << std::endl;
+    return 0;
+}
+```
+
+### CI/CD Pipeline
+
+Every PR triggers automatic checks:
+- ✅ Project compilation (CMake + Ninja)
+- ✅ Unit tests execution
+- ✅ Code style verification (`cppcheck`, `clang-tidy`)
+
+**Merge is blocked if:**
+- ❌ Tests fail
+- ❌ Style checks return errors
+- ❌ Build fails
+
+---
+
+## 📚 Documentation
+
+### Required Documentation
+
+When adding new features, update:
+
+1. **Code Documentation** (Doxygen comments)
+2. **API Documentation** (if library/public API)
+3. **README files** (in relevant directories)
+4. **Examples** (in `/examples/` if applicable)
+5. **This CONTRIBUTING.md** (if workflow changes)
+
+### Map Files Standard
+
+When creating maps, follow [MAPS_STANDARD.md](./docs/MAPS_STANDARD.md):
+
+- Place maps in `/assets/maps/`
+- Each map in its own directory
+- Include both `.def` and `.map` files
+- Use ASCII characters only
+- No tabs in `.map` files (spaces only)
+
+Example:
+```
+assets/maps/
+└── my-map/
+    ├── my-map.def    # Definitions
+    └── my-map.map    # Layout
+```
+
+---
+
+## 💬 Communication
+
+### Channels
+
+- **Discord**: All technical communication
+  - `#absent-retard`: Report absences/delays
+  - `#sondage`: Team votes on technical decisions
+- **Notion**: Meeting retranscriptions and documentation
+- **GitHub**: Code reviews, issues, PRs
+
+### Best Practices
+
+- 🕐 Respect meeting schedules
+- 💬 Avoid digressions during stand-ups
+- 🔔 Never block others without communication
+- 📊 Update GitHub Projects as tasks progress
+- 🗳️ Use team votes for unresolved technical disagreements
+
+### Reporting Issues
+
+When opening an issue:
+
+1. **Check existing issues** first
+2. **Use a clear title** describing the problem
+3. **Provide details**:
+   - Steps to reproduce
+   - Expected vs actual behavior
+   - Environment (OS, compiler, etc.)
+   - Code snippets if applicable
+4. **Add labels** (bug, enhancement, documentation, etc.)
+5. **Assign to milestone** if applicable
+
+---
+
+## 👀 Review Process
+
+### As a Reviewer
+
+- ✅ Check code quality and style
+- ✅ Verify tests are included and passing
+- ✅ Ensure documentation is updated
+- ✅ Test the changes locally if possible
+- ✅ Provide constructive feedback
+- ✅ Approve only when fully satisfied
+
+### As a Contributor
+
+- ✅ Respond to all review comments
+- ✅ Make requested changes promptly
+- ✅ Re-request review after updates
+- ✅ Keep PR scope focused (one feature/fix per PR)
+- ✅ Keep commits clean and well-organized
+
+### Review Checklist
+
+Before approving a PR, verify:
+
+- [ ] Code follows style guidelines
+- [ ] All tests pass
+- [ ] New tests added for new features
+- [ ] Documentation updated
+- [ ] No unnecessary files committed
+- [ ] Commit messages follow conventions
+- [ ] PR description is clear and complete
+- [ ] Copilot summary generated
+- [ ] Related issues linked
+
+---
+
+## 🎯 Quick Reference
+
+### Starting a New Feature
+
+```bash
+# 1. Create branch
+git checkout -b feat/scope/feature-name
+
+# 2. Make changes and commit
+git add .
+git commit -m "feat: add feature description #issue"
+
+# 3. Push and create PR
+git push origin feat/scope/feature-name
+# Then create PR on GitHub
+
+# 4. Link to GitHub Project and move to "In Review"
+```
+
+### Before Submitting PR
+
+- [ ] Code compiles without warnings
+- [ ] All tests pass locally
+- [ ] Documentation updated
+- [ ] Code follows style guide
+- [ ] Commit messages follow convention
+- [ ] Branch up to date with `dev`
+
+### After PR Approved
+
+```bash
+# Squash and merge via GitHub interface
+# Delete branch after merge
+git branch -d feat/scope/feature-name
+git push origin --delete feat/scope/feature-name
+```
+
+---
+
+## 📖 Additional Resources
+
+- [Git Standards](./docs/GIT_STANDARD.md) - Detailed Git workflow
+- [Coding Style](./docs/CODING_STYLE.md) - Complete coding standards
+- [Organization](./docs/ORGANISATION.md) - Team organization and meetings
+- [Maps Standard](./docs/MAPS_STANDARD.md) - Map file format specification
+- [Code of Conduct](./docs/CODE_OF_CONDUCT.md) - Community guidelines
+
+---
+
+## 🤝 Getting Help
+
+### Technical Issues
+
+1. Check existing documentation
+2. Search closed issues on GitHub
+3. Ask in Discord technical channels
+4. Create a new issue if problem persists
+
+### Process Questions
+
+1. Refer to this CONTRIBUTING.md
+2. Check specific docs (GIT_STANDARD, CODING_STYLE, etc.)
+3. Ask team lead: @mrGonzalezGomez on Discord
+4. Discuss in weekly meeting if needed
+
+---
+
+## 🎉 Recognition
+
+Contributors who follow these guidelines and actively participate in the project will be recognized in:
+- Project README
+- Release notes
+- Team meetings
+
+Thank you for contributing to R-Type! Your efforts help make this project better for everyone. 🚀
+
+---
+
+**Questions or concerns?** Contact the project maintainer: [morgan.guichard@epitech.eu](mailto:morgan.guichard@epitech.eu)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 ## Developer Docs
+- 🤝 [**Contributing Guide**](./CONTRIBUTING.md) - **Start here!** Complete guide for contributors
+- [Code of Conduct](./docs/CODE_OF_CONDUCT.md)
 - [Git Standards](./docs/GIT_STANDARD.md)
 - [Coding Style Guidelines](./docs/CODING_STYLE.md)
 - [Organisation Rules](./docs/ORGANISATION.md)
-- [Schéma ULM](./archi_mindmap/README.md)
+- [Maps Standard](./docs/MAPS_STANDARD.md)
+- [Schéma UML](./archi_mindmap/README.md)

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+morgan.guichard@epitech.eu.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -1,0 +1,187 @@
+# 🚀 R-Type Contributor Quick Reference
+
+> Quick commands and checklists for daily development
+
+## 📝 Daily Workflow
+
+### Starting Work
+```bash
+# 1. Pull latest changes
+git checkout dev
+git pull origin dev
+
+# 2. Create feature branch
+git checkout -b feat/scope/my-feature
+
+# 3. Make changes...
+```
+
+### Committing Changes
+```bash
+# Stage changes
+git add .
+
+# Commit with proper format
+git commit -m "feat: add authentication system #42"
+#              ↑     ↑                          ↑
+#            action  description            issue #
+
+# Push to remote
+git push -u origin feat/scope/my-feature
+```
+
+### Creating Pull Request
+1. Go to GitHub and create PR
+2. Add Copilot summary to description
+3. Add `closes #issue_number` at bottom
+4. Link to GitHub Project (Development tab)
+5. Move ticket to "In Review"
+
+---
+
+## 📋 Commit Actions
+
+| Action | Use Case | Example |
+|--------|----------|---------|
+| `feat` | New feature | `feat: add user login #42` |
+| `fix` | Bug fix | `fix: resolve memory leak #87` |
+| `refacto` | Code refactoring | `refacto: optimize parser #65` |
+| `docs` | Documentation | `docs: update API docs #91` |
+
+---
+
+## 🌿 Branch Naming
+
+```
+{type}/{scope}/{topic}
+  ↓       ↓       ↓
+feat/server/auth-system
+fix/client/crash-on-start
+refacto/ecs/components
+docs/mapparser/examples
+```
+
+**Common Scopes:**
+- `server`, `client`, `ecs`, `mapparser`
+- `cicd`, `tests`, `network`, `graphics`
+
+---
+
+## ✅ Pre-Commit Checklist
+
+- [ ] Code compiles: `cmake --build build`
+- [ ] Tests pass: `cd build && ctest`
+- [ ] Style is correct (no warnings)
+- [ ] Documentation updated
+- [ ] Following naming conventions
+
+---
+
+## 🧪 Testing
+
+```bash
+# Build project
+cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
+cmake --build build --parallel $(nproc)
+
+# Run all tests
+cd build
+ctest --output-on-failure
+
+# Run specific test
+./tests/test_mapparser
+```
+
+---
+
+## 📅 Meetings
+
+### Daily (Tue-Wed)
+- **10:00 AM** (15 min max)
+- 3 questions: Yesterday? Today? Blockers?
+- ➡️ Retranscribe on Notion
+
+### Weekly (Monday)
+- **2:00 PM** (30-60 min)
+- Sprint planning & task assignment
+- `dev → main` merge if ready
+- ➡️ Retranscribe on Notion
+
+---
+
+## 🎯 Naming Conventions
+
+```cpp
+class PlayerManager          // PascalCase
+void getPlayerName()         // camelCase
+int player_count = 0;        // snake_case
+const int MAX_PLAYERS = 100; // UPPERCASE
+namespace network { }        // lowercase
+```
+
+---
+
+## 📖 Documentation Template
+
+```cpp
+/**
+ * @brief Brief description.
+ * @param param_name Parameter description.
+ * @return Return value description.
+ * @throws std::exception If error occurs.
+ */
+void myFunction(int param_name);
+```
+
+---
+
+## 🚫 Common Mistakes
+
+❌ `#pragma once` → ✅ Use `#ifndef`
+❌ `using namespace std;` → ✅ Use `std::` prefix
+❌ Direct merge to main → ✅ PR with reviews
+
+---
+
+## 🆘 Quick Help
+
+| Need | Resource |
+|------|----------|
+| Full guide | [CONTRIBUTING.md](./CONTRIBUTING.md) |
+| Git rules | [docs/GIT_STANDARD.md](./docs/GIT_STANDARD.md) |
+| Code style | [docs/CODING_STYLE.md](./docs/CODING_STYLE.md) |
+| Team org | [docs/ORGANISATION.md](./docs/ORGANISATION.md) |
+| Map format | [docs/MAPS_STANDARD.md](./docs/MAPS_STANDARD.md) |
+| Conduct | [docs/CODE_OF_CONDUCT.md](./docs/CODE_OF_CONDUCT.md) |
+
+---
+
+## 💬 Communication
+
+- **Technical**: Discord
+- **Absence/Delay**: Discord `#absent-retard`
+- **Votes**: Discord `#sondage`
+- **Documentation**: Notion
+- **Code**: GitHub PRs
+- **Tickets**: GitHub Issues/Projects
+
+---
+
+## ⚡ Speed Commands
+
+```bash
+# Quick build
+alias rbuild='rm -rf build && cmake -B build -G Ninja && cmake --build build --parallel $(nproc)'
+
+# Run tests
+alias rtest='cd build && ctest --output-on-failure'
+
+# Format check
+alias rcheck='cppcheck client server lib'
+```
+
+---
+
+**Save this file and keep it handy! 📌**
+
+For detailed information, always refer to [CONTRIBUTING.md](./CONTRIBUTING.md)


### PR DESCRIPTION
This pull request improves contributor onboarding and project documentation by adding a Contributor Covenant Code of Conduct, a quick reference guide for contributors, and updating the developer documentation links in the `README.md`. These changes make it easier for new and existing contributors to understand project standards, workflows, and expectations.

**Documentation and Contributor Experience Improvements:**

* Added a comprehensive Contributor Covenant Code of Conduct in `docs/CODE_OF_CONDUCT.md` to establish clear standards for behavior and enforcement guidelines for all community members.
* Introduced `docs/QUICK_REFERENCE.md`, a quick reference guide covering daily workflow, commit and branch conventions, testing, meetings, naming conventions, documentation templates, common mistakes, and communication channels.
* Updated the `README.md` to link to the new Contributing Guide, Code of Conduct, Maps Standard, and correct the UML schema link, making it easier to find key contributor resources.
closes #105 