### PR TITLE
fix: updated the max number of character for the username down to 15.

### DIFF
--- a/client/src/gui/MainMenuState.cpp
+++ b/client/src/gui/MainMenuState.cpp
@@ -152,7 +152,7 @@ namespace rtype::client::gui {
                 }
             }
             else if (event.text.unicode >= 32 && event.text.unicode < 127) {
-                if (username.length() < 20) { // Max username length
+                if (username.length() < 15) { // Max username length
                     username += static_cast<char>(event.text.unicode);
                 }
             }


### PR DESCRIPTION
Updated the max number of character that the username can write down in the main menu of the game down to 15 characters

closes #124 